### PR TITLE
GH-21 support for counter metrics with horizontal DB

### DIFF
--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/ObservationDefinitionConfig.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/ObservationDefinitionConfig.java
@@ -27,6 +27,7 @@ public class ObservationDefinitionConfig {
   private String objectName;
   private String path;
   private String metricNamespace;
+  private String rowIdColumns;
 
   private List<MetricConfig> metric = Collections.EMPTY_LIST;
   private List<TagConfig> tag = Collections.EMPTY_LIST;
@@ -104,5 +105,13 @@ public class ObservationDefinitionConfig {
 
   public void setFunc(List<FunctionInvokerConfig> func) {
     this.func = func;
+  }
+
+  public String getRowIdColumns() {
+    return rowIdColumns;
+  }
+
+  public void setRowIdColumns(String rowIdColumns) {
+    this.rowIdColumns = rowIdColumns;
   }
 }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/db/DbObservation.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/db/DbObservation.java
@@ -19,8 +19,11 @@
  */
 package com.sematext.spm.client.db;
 
+import org.eclipse.collections.impl.list.mutable.FastList;
+
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -37,15 +40,19 @@ public class DbObservation extends ObservationBean<DbAttributeObservation, Map<S
 
   private String beanName;
 
+  private List<String> rowIdColumns;
+  
   // used when instantiating a "real" DbObservation object for some particular db bean (resulting object is not just a 
   // config holder anymore)
   public DbObservation(DbObservation orig, String beanName) {
     super(orig, Collections.EMPTY_MAP);
     this.beanName = beanName;
+    this.rowIdColumns = orig.getRowIdColumns();
   }
 
   public DbObservation(ObservationDefinitionConfig observationDefinition) throws ConfigurationFailedException {
     super(observationDefinition);
+    readRowIdColumns(observationDefinition);
   }
 
   public ObservationBean getCopy() throws ConfigurationFailedException {
@@ -91,6 +98,23 @@ public class DbObservation extends ObservationBean<DbAttributeObservation, Map<S
     // readAttributeNameMappings(observationDefinition);
     readIgnoreElements(observationDefinition);
     readAcceptElements(observationDefinition);
+    
+    readRowIdColumns(observationDefinition);
+  }
+
+  private void readRowIdColumns(ObservationDefinitionConfig observationDefinition) {
+    if (observationDefinition.getRowIdColumns() != null) {
+      rowIdColumns = new FastList<String>();
+      for (String id : observationDefinition.getRowIdColumns().split(",")) {
+        id = id.trim();
+        if (!id.equals("")) {
+          rowIdColumns.add(id);
+        }
+      }
+    }
+    if (rowIdColumns != null && rowIdColumns.isEmpty()) {
+      rowIdColumns = null;
+    }
   }
 
   @Override
@@ -114,5 +138,9 @@ public class DbObservation extends ObservationBean<DbAttributeObservation, Map<S
       LOG.error("Unknown attribute observation type: " + type);
       return null;
     }
+  }
+
+  public List<String> getRowIdColumns() {
+    return rowIdColumns;
   }
 }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractor.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractor.java
@@ -19,6 +19,8 @@
  */
 package com.sematext.spm.client.db;
 
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -29,29 +31,47 @@ import com.sematext.spm.client.observation.ObservationBeanDump;
 
 public class DbStatsExtractor extends StatsExtractor<DbStatsExtractorConfig, DbObservation> {
   private static final Set<ObservationBeanDump> EMPTY_OBSERVATION_BEAN_DUMP = new HashSet<ObservationBeanDump>();
+  private static final int DEFAULT_COPIES_MAP_SIZE = 50;
 
   private DbDataSourceBase dataSource;
+  
+  private Map<DbObservation, Map<String, DbObservation>> allObservationCopies;
 
   public DbStatsExtractor(DbStatsExtractorConfig config) {
     super(config);
 
     dataSource = DbDataSourceCachedFactory
         .getDataSource(config.getDbUrl(), config.getDataRequestQuery(), config.isDbVerticalDataModel());
+    
+    allObservationCopies = new UnifiedMap<>(config.getObservations().size());
   }
-
+  
   @Override
   protected Set<ObservationBeanDump> collectObservationStats(DbObservation observation) {
     Set<ObservationBeanDump> finalDump = null;
-
+    Map<DbObservation, Map<String, DbObservation>> usedObservationCopies =
+        new UnifiedMap<>(allObservationCopies.size());
+    
     List<Map<String, Object>> data = dataSource.fetchData();
 
     if (data == null) {
       return EMPTY_OBSERVATION_BEAN_DUMP;
     }
 
-    boolean createCopies = data.size() > 1;
+    boolean createCopies = data.size() > 1 && !hasRowIdsDefined(observation);
+    
     for (Map<String, Object> rowData : data) {
-      Set<ObservationBeanDump> singleDump = observation.collectStats(rowData);
+      DbObservation collectingObservation;
+      String obsKey = createObservationKey(observation, rowData);
+      
+      if (obsKey == null) {
+        collectingObservation = observation;
+      } else {
+        collectingObservation = getObservationByKey(observation, obsKey);
+        rememberCopyUsed(usedObservationCopies, observation, collectingObservation, obsKey);
+      }
+      
+      Set<ObservationBeanDump> singleDump = collectingObservation.collectStats(rowData);
       if (singleDump.size() == 0) {
         continue;
       } else if (singleDump.size() == 1) {
@@ -71,10 +91,61 @@ public class DbStatsExtractor extends StatsExtractor<DbStatsExtractorConfig, DbO
       }
     }
 
+    // drop any copies unused in this run to avoid filling memory with unused observations
+    allObservationCopies = usedObservationCopies;
+    
     if (finalDump == null || finalDump.size() == 0) {
       return EMPTY_OBSERVATION_BEAN_DUMP;
     } else {
       return finalDump;
+    }
+  }
+
+  private boolean hasRowIdsDefined(DbObservation observation) {
+    return observation.getRowIdColumns() != null && !observation.getRowIdColumns().isEmpty();
+  }
+
+  private void rememberCopyUsed(Map<DbObservation, Map<String, DbObservation>> usedObservationCopies,
+      DbObservation origObservation, DbObservation copy, String obsKey) {
+    Map<String, DbObservation> copies = usedObservationCopies.get(origObservation);
+    
+    if (copies == null) {
+      Map<String, DbObservation> previousCopies = allObservationCopies.get(origObservation);
+      copies = new UnifiedMap<String, DbObservation>(previousCopies != null ? previousCopies.size() :
+        DEFAULT_COPIES_MAP_SIZE);
+      usedObservationCopies.put(origObservation, copies);
+    }
+    
+    copies.put(obsKey, copy);
+  }
+
+  private DbObservation getObservationByKey(DbObservation origObservation, String obsKey) {
+    Map<String, DbObservation> copies = allObservationCopies.get(origObservation); 
+    
+    if (copies == null) {
+      copies = new UnifiedMap<String, DbObservation>(DEFAULT_COPIES_MAP_SIZE);
+      allObservationCopies.put(origObservation, copies);
+    }
+    
+    DbObservation copy = copies.get(obsKey);
+    
+    if (copy == null) {
+      copy = new DbObservation(origObservation, origObservation.getName() + ":" + obsKey);
+      copies.put(obsKey, copy);
+    }
+    
+    return copy;
+  }
+
+  private String createObservationKey(DbObservation observation, Map<String, Object> rowData) {
+    if (observation.getRowIdColumns() == null || observation.getRowIdColumns().isEmpty()) {
+      return null;
+    } else {
+      String key = "";
+      for (String id : observation.getRowIdColumns()) {
+        key += rowData.get(id) + "_";
+      }
+      return key;
     }
   }
 

--- a/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractor.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractor.java
@@ -43,14 +43,14 @@ public class DbStatsExtractor extends StatsExtractor<DbStatsExtractorConfig, DbO
     dataSource = DbDataSourceCachedFactory
         .getDataSource(config.getDbUrl(), config.getDataRequestQuery(), config.isDbVerticalDataModel());
     
-    allObservationCopies = new UnifiedMap<>(config.getObservations().size());
+    allObservationCopies = new UnifiedMap<DbObservation, Map<String, DbObservation>>(config.getObservations().size());
   }
   
   @Override
   protected Set<ObservationBeanDump> collectObservationStats(DbObservation observation) {
     Set<ObservationBeanDump> finalDump = null;
     Map<DbObservation, Map<String, DbObservation>> usedObservationCopies =
-        new UnifiedMap<>(allObservationCopies.size());
+        new UnifiedMap<DbObservation, Map<String, DbObservation>>(allObservationCopies.size());
     
     List<Map<String, Object>> data = dataSource.fetchData();
 

--- a/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractorConfig.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractorConfig.java
@@ -71,15 +71,17 @@ public class DbStatsExtractorConfig extends StatsExtractorConfig<DbObservation> 
     }
 
     if (!dbVerticalDataModel) {
-      // when horizontal db model is used, allow only gauge and text attributes to be used
+      // when horizontal db model is used allow only gauge and text attribute unless rowIdolumns are defined
       for (DbObservation dbo : getObservations()) {
         for (DbAttributeObservation dba : dbo.getAttributeObservations()) {
           MetricType metricType = dba.getMetricType();
           if (metricType != MetricType.GAUGE && metricType != MetricType.TEXT) {
-            throw new ConfigurationFailedException("Found metric " + dba.getFinalName() + " of type " + metricType +
-                                                       " defined in combination with dbVerticalDataModel="
-                                                       + dbVerticalDataModel + ". Such combination is currently" +
-                                                       " not supported, only gauge and text types are allowed when dbVerticalDataModel=false");
+            if (dbo.getRowIdColumns() == null || dbo.getRowIdColumns().isEmpty()) {
+              throw new ConfigurationFailedException("Found metric " + dba.getFinalName() + " of type " + metricType +
+                  " defined in combination with dbVerticalDataModel=" + dbVerticalDataModel +
+                  ". Such combination is allowed only if rowIdColumns attribute is specified as well " +
+                  "(since agent has to be able to uniquely identify each result row)");              
+            }
           }
         }
       }


### PR DESCRIPTION
As described in #21, this PR brings support Agent was missing. Implementation creates N internal observation beans where each of them is dedicated for collection of metrics for particular row (identified by values of specified rowIdColumns). We don't enforce uniqueness, if user didn't choose rowIds well, agent will internally aggregate metrics with same combination of rowIdColumns values into single output entry.