### PR TITLE
Fix for json function expression not evaluated

### DIFF
--- a/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonUtil.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonUtil.java
@@ -182,13 +182,7 @@ public final class JsonUtil {
       int indexOfArrayDefOpen = node.indexOf("[");
       int lastIndexOfArrayDefClose = node.lastIndexOf("]");
 
-      boolean function = node.replaceAll(" ","").endsWith("()");
-      if (function) {
-        // function should be the last node in the expression.
-        if (i != nodes.length - 1) {
-          throw new IllegalArgumentException("function should be the last node in the expression.");
-        }
-      }
+
 
       boolean array = false;
       boolean arrayMatchAll = false;
@@ -247,10 +241,6 @@ public final class JsonUtil {
         if (node.trim().equals("")) {
           traverseNode(pathSoFar + "." + node + arrayPartOfPath, nodes, i, allMatchingPaths, pathAttributes, array,
                   arrayMatchAll, arrayExpression, jsonNodeData);
-        } else if (function) {
-          Object result = evaluateFunction(node, jsonNodeData);
-          allMatchingPaths.add(new JsonMatchingPath(pathSoFar, Collections.EMPTY_MAP, result));
-          return;
         } else {
           throw new UnsupportedOperationException("Lists were supposed to be handled differently");
         }
@@ -293,9 +283,21 @@ public final class JsonUtil {
 //      EXPRESSION_NODES.put(expression, expressionNodes);
 //    }
 
+    int i = 0;
     for (String exNode : expressionNodes) {
+      i++;
       if (jsonNodeData == null) {
         return null;
+      }
+      if (exNode.contains("(")) {
+        boolean function = exNode.replaceAll(" ", "").endsWith("()");
+        if (function) {
+          // function should be the last node in the expression.
+          if (i != expressionNodes.length) {
+            throw new IllegalArgumentException("function should be the last node in the expression.");
+          }
+          jsonNodeData = evaluateFunction(exNode, jsonNodeData);
+        }
       } else {
         jsonNodeData = ((Map<String, Object>) jsonNodeData).get(exNode);
       }

--- a/spm-monitor/src/test/java/com/sematext/spm/client/json/JsonUtilTest.java
+++ b/spm-monitor/src/test/java/com/sematext/spm/client/json/JsonUtilTest.java
@@ -24,20 +24,13 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class JsonUtilTest {
   @Test
@@ -616,12 +609,11 @@ public class JsonUtilTest {
     };
     Map<String, Object> jsonData = new ObjectMapper(new JsonFactory()).readValue(response, typeRef);
 
-    List<JsonMatchingPath> paths = JsonUtil.findMatchingPaths(jsonData, "$.upstreams.hg-backend.peers.length()");
-    Assert.assertEquals(2, paths.get(0).getMatchedObject());
+    List<JsonMatchingPath> paths = JsonUtil.findMatchingPaths(jsonData, "$.upstreams.hg-backend");
+    Assert.assertEquals(2, JsonUtil.findValueIn("peers.length()", paths.get(0).getMatchedObject()));
 
-    paths = JsonUtil.findMatchingPaths(jsonData, "$.stream.upstreams.unused_tcp_backends.peers.length ( )");
-    Assert.assertEquals(4, paths.get(0).getMatchedObject());
-
+    paths = JsonUtil.findMatchingPaths(jsonData, "$.stream.upstreams.unused_tcp_backends");
+    Assert.assertEquals(4, JsonUtil.findValueIn("peers.length()", paths.get(0).getMatchedObject()));
     response.close();
 
     response = getClass().getResourceAsStream("json-response.json");
@@ -629,10 +621,10 @@ public class JsonUtilTest {
     };
     jsonData = new ObjectMapper(new JsonFactory()).readValue(response, typeRef);
 
-    paths = JsonUtil.findMatchingPaths(jsonData, "$.books.book.ratings.max()");
-    Assert.assertEquals(5.0, paths.get(0).getMatchedObject());
+    paths = JsonUtil.findMatchingPaths(jsonData, "$.books.book");
+    Assert.assertEquals(5.0, JsonUtil.findValueIn("ratings.max()", paths.get(0).getMatchedObject()));
 
-    paths = JsonUtil.findMatchingPaths(jsonData, "$.books.book.ratings.min()");
-    Assert.assertEquals(2.5, paths.get(0).getMatchedObject());
+    paths = JsonUtil.findMatchingPaths(jsonData, "$.books.book");
+    Assert.assertEquals(2.5, JsonUtil.findValueIn("ratings.min()", paths.get(0).getMatchedObject()));
   }
 }


### PR DESCRIPTION
I wrongly assumed the function will be part of json expression. Instead, it will be the part metric source. fixed, adjusted tests and verified with ES collectors