### PR TITLE
SC-3855: Fix security issues in App Agent

### DIFF
--- a/spm-client-common-libs-parent/pom.xml
+++ b/spm-client-common-libs-parent/pom.xml
@@ -73,28 +73,28 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.5</version>
+      <version>2.9.8</version>
       <scope>${common.lib.scope}</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version>
+      <version>2.9.8</version>
       <scope>${common.lib.scope}</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-smile</artifactId>
-      <version>2.9.5</version>
+      <version>2.9.8</version>
       <scope>${common.lib.scope}</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.5</version>
+      <version>2.9.8</version>
       <scope>${common.lib.scope}</scope>
     </dependency>
 
@@ -362,13 +362,6 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.4</version>
-      <scope>${common.lib.scope}</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.5</version>
       <scope>${common.lib.scope}</scope>
     </dependency>
   </dependencies>

--- a/spm-tracing-agent/pom.xml
+++ b/spm-tracing-agent/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>0.9.2.1</version>
+      <version>0.9.5.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/spm-tracing-testing/common/pom.xml
+++ b/spm-tracing-testing/common/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>0.9.2.1</version>
+      <version>0.9.5.3</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
- Update Jackson version to 2.9.8
- Update c3p0 to 0.9.5.3 (used only in test )
- Remove redundant dependency

- verified startup of the agent in standalone + in-process ( YAML loading ) and ES metrics collection ( json)