### PR TITLE
SC-3855: Fix security issues in App Agent (part 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
   - sudo apt-get install ruby ruby-dev rubygems-integration build-essential rpm
   - gem install --no-ri --no-rdoc fpm
   - sudo apt-get install automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config
-  - wget http://www.us.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
-  - tar xfz thrift-0.9.3.tar.gz
-  - cd thrift-0.9.3 && ./configure --enable-libs=no  && sudo make install
+  - wget http://www.us.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz
+  - tar xfz thrift-0.12.0.tar.gz
+  - cd thrift-0.12.0 && ./configure --enable-libs=no  && sudo make install
 script:
   - cd $TRAVIS_BUILD_DIR && ./build.sh

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ To build Sematext App Agent you need:
 1) Linux based Operating System 
 2) Java 1.6+
 3) Maven 
-4) Thrift compiler v0.9.3
+4) Thrift compiler v0.12.0
     * Steps to install Thrift in Debian based systems
         ```bash
           sudo apt-get install automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config
-          wget http://www.us.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
-          tar xfz thrift-0.9.3.tar.gz
-          cd thrift-0.9.3 && ./configure --enable-libs=no  && sudo make install
+          wget http://www.us.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz
+          tar xfz thrift-0.12.0.tar.gz
+          cd thrift-0.12.0 && ./configure --enable-libs=no  && sudo make install
         ```
 5) fpm package manager 
     * For steps to install fpm refer [https://fpm.readthedocs.io/en/latest/installing.html](https://fpm.readthedocs.io/en/latest/installing.html)

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -18,8 +18,8 @@
  -->
 
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
 
@@ -49,7 +49,6 @@
 -->
 
 <module name="Checker">
-  <module name="SuppressionCommentFilter"/>
   <!-- Checks that a package.html file exists for each package.     -->
   <!-- See http://checkstyle.sf.net/config_javadoc.html#PackageHtml -->
   <!--module name="PackageHtml"/-->
@@ -98,8 +97,6 @@
 
 
   <module name="TreeWalker">
-
-    <module name="FileContentsHolder"/>
 
     <property name="cacheFile" value="${checkstyle.cache.file}"/>
 
@@ -166,7 +163,7 @@
     <module name="NoWhitespaceAfter">
       <!-- Default tokens without ARRAY_INIT and additional GENERIC_START -->
       <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT,
-                                         UNARY_MINUS, UNARY_PLUS, GENERIC_START"/>
+                                         UNARY_MINUS, UNARY_PLUS"/>
     </module>
     <module name="NoWhitespaceBefore">
       <!-- Default tokens and additional GENERIC_START and GENERIC_END -->
@@ -175,7 +172,7 @@
     </module>
     <module name="WhitespaceAfter">
       <!-- Default tokens and additional GENERIC_END -->
-      <property name="tokens" value="COMMA, SEMI, TYPECAST, GENERIC_END"/>
+      <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
     </module>
     <module name="WhitespaceAround">
       <!-- Default tokens without GENERIC_START, GENERIC_END and WILDCARD_TYPE -->
@@ -204,9 +201,7 @@
     <!-- See http://checkstyle.sf.net/config_blocks.html -->
     <module name="AvoidNestedBlocks"/>
     <module name="EmptyBlock"/>
-    <module name="LeftCurly">
-      <property name="maxLineLength" value="120"/>
-    </module>
+    <module name="LeftCurly"/>
     <module name="NeedBraces"/>
     <module name="RightCurly"/>
 
@@ -221,7 +216,6 @@
       <property name="severity" value="ignore"/>
     </module>
     <module name="MissingSwitchDefault"/>
-    <module name="RedundantThrows"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
 
@@ -247,8 +241,8 @@
       <property name="severity" value="warning"/>
     </module>
     <module name="UpperEll"/>
-
+    <module name="SuppressionCommentFilter"/>
   </module>
 
-  <module name="SuppressionCommentFilter"/>
+
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.12</version>
+                    <version>3.0.0</version>
                     <executions>
                         <execution>
                             <phase>compile</phase>
@@ -56,12 +56,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>5.7</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>xerces</groupId>
-                            <artifactId>xercesImpl</artifactId>
-                            <version>2.8.1</version>
+                            <version>8.18</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/spm-client-common-libs-parent/pom.xml
+++ b/spm-client-common-libs-parent/pom.xml
@@ -202,7 +202,7 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>0.9.1</version>
+      <version>0.12.0</version>
     </dependency>
 
     <!-- including version we know works for us -->

--- a/spm-thrift-data/pom.xml
+++ b/spm-thrift-data/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>0.9.1</version>
+      <version>0.12.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This PR

1) Updates checkstyle to 8.18 and updates the maven-checkstyle plugin to 3.0.0. Updated the rules as per the latest version. Made sure checkstyle goal is passing
2) Updates libthrift to 0.12.0 - verified profiling and transaction tracing working from in-process agent