### PR TITLE
SC-4551: Add os.host to all container-related metrics sent from AAs

### DIFF
--- a/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
@@ -249,7 +249,7 @@ public abstract class GenericExtractor<S extends StatsExtractorConfig<O>, T exte
     File monitorPropertiesFile = monitorConfig.getMonitorPropertiesFile();
 
     partlyResolvedObservationConfigTags
-        .put(OS_HOST_TAG, SenderUtil.calculateHostParameterValue(monitorPropertiesFile, monitorProperties));
+        .put(OS_HOST_TAG, SenderUtil.calculateHostParameterValue());
 
     String dockerHostname = SenderUtil.getDockerHostname();
     if (dockerHostname != null) {

--- a/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
@@ -31,7 +31,7 @@ public final class StatValuesHelper {
 
   public static void fillHostTags(StatValues statValues, File propsFile) {
     try {
-      statValues.getTags().put("os.host", SenderUtil.calculateHostParameterValue(propsFile));
+      statValues.getTags().put("os.host", SenderUtil.calculateHostParameterValue());
     } catch (Throwable thr) {
       LOG.warn("Can't resolve os.host value, setting to unknown", thr);
       statValues.getTags().put("os.host", "unknown");

--- a/spm-sender/src/main/java/com/sematext/spm/client/sender/SenderUtil.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/sender/SenderUtil.java
@@ -211,20 +211,8 @@ public final class SenderUtil {
   private static long lastHostCalculationTime = -1l;
   private static String lastHostname = "unknown";
 
-  public synchronized static String calculateHostParameterValue(File monitorPropertiesFile)
-      throws FileNotFoundException, IOException {
-    long currentTime = System.currentTimeMillis();
-    if (lastHostCalculationTime != -1 && (lastHostCalculationTime + hostnameReadIntervalMs) > currentTime) {
-      return lastHostname;
-    }
 
-    Properties monitorProperties = new Properties();
-    monitorProperties.load(new FileInputStream(monitorPropertiesFile));
-    return calculateHostParameterValue(monitorPropertiesFile, monitorProperties);
-  }
-
-  public synchronized static String calculateHostParameterValue(File monitorPropertiesFile,
-                                                                Properties monitorProperties) {
+  public synchronized static String calculateHostParameterValue() {
     long currentTime = System.currentTimeMillis();
     if (lastHostCalculationTime != -1 && (lastHostCalculationTime + hostnameReadIntervalMs) > currentTime) {
       return lastHostname;
@@ -233,13 +221,13 @@ public final class SenderUtil {
     lastHostCalculationTime = currentTime;
 
     if (DOCKER_SETUP_FILE.exists()) {
-      String containerHostname = MonitorUtil.getContainerHostname(monitorPropertiesFile, monitorProperties);
-      if (containerHostname != null && !containerHostname.trim().equals("")) {
-        LOG.info("Resolved hostname to " + containerHostname + " based on calculated container hostname");
-        lastHostname = containerHostname;
-        return containerHostname;
+      String containerHostHostname = getDockerHostname();
+      if (containerHostHostname != null && !containerHostHostname.trim().equals("")) {
+        LOG.info("Resolved hostname to " + containerHostHostname + " based on calculated container host hostname");
+        lastHostname = containerHostHostname;
+        return containerHostHostname;
       } else {
-        LOG.warn("Couldn't resolve container hostname, returning value 'unknown'");
+        LOG.warn("Couldn't resolve container host hostname, returning value 'unknown'");
         lastHostname = "unknown";
         return lastHostname;
       }

--- a/spm-sender/src/main/java/com/sematext/spm/client/sender/bootstrap/SenderFlumeAgentFactory.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/sender/bootstrap/SenderFlumeAgentFactory.java
@@ -199,7 +199,7 @@ public final class SenderFlumeAgentFactory {
     // NOTE: hostname interceptor not used anymore since we try to optimize creation of bulk URLs (recreate only when hostname changes)
 
     properties.put(CustomElasticSearchRestClient.URL_PARAM_HOST, SenderUtil
-        .calculateHostParameterValue(monitorPropertiesFile, monitorProperties));
+        .calculateHostParameterValue());
     properties.put(CustomElasticSearchRestClient.URL_PARAM_DOCKER_HOSTNAME, SenderUtil.getDockerHostname());
     properties.put(CustomElasticSearchRestClient.URL_PARAM_CONTAINER_HOSTNAME, MonitorUtil
         .getContainerHostname(monitorPropertiesFile, monitorProperties));


### PR DESCRIPTION
Adjusted `os.host` tag to use the same value of `container.host.hostname` in case of docker env (this is read from .docker file).  Earlier is was returning the `container.hostname` value. 

Verified by running app-agent docker and package install. 

**old stats**
```
jvm,token=bd93e778-b4e6-4fba-bc51-c4b677234382,jvm=default,container.hostname=192.168.0.5,container.host.hostname=optimus-prime,os.host=192.168.0.5,jvm.memory.pool=PS\ Survivor\ Space pool.used=2628600i,pool.max=22020096i 1556624452833000000
```

**new stats**
```
jvm,token=bd93e778-b4e6-4fba-bc51-c4b677234382,jvm=default,container.hostname=192.168.0.5,container.host.hostname=optimus-prime,os.host=optimus-prime,jvm.memory.pool=PS\ Old\ Gen pool.used=8192i,pool.max=5624561664i 1556632439000000000
```