### PR TITLE
SC-4946: Send container id, name and image as tags for application metrics

### DIFF
--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -31,21 +31,21 @@ case $1 in
          bash \
             $SPM_HOME/bin/setup-spm  \
             --start-agent false \
-            --monitoring-token $MONITORING_TOKEN   \
-            --app-type $APP_TYPE  \
-            --app-subtype $APP_SUBTYPE \
-            --agent-type $AGENT_TYPE \
-            --jvm-name $JVM_NAME \
-            --jmx-params $JMX_PARAMS \
-            --metrics-receiver $METRICS_RECEIVER \
-            --tracing-receiver $TRACE_RECEIVER \
-            --region $REGION \
-            --jmx-host $JMX_HOST \
-            --jmx-port $JMX_PORT \
-            --jmx-pass-file $JMX_PASS_FILE \
-            --jmx-trust-store $JMX_TRUSTSTORE \
-            --jmx-trust-store-pass $JMX_TRUSTSTORE_PASS \
-            $EXTRA_PARAMS
+            --monitoring-token "$MONITORING_TOKEN"   \
+            --app-type "$APP_TYPE"  \
+            --app-subtype "$APP_SUBTYPE" \
+            --agent-type "$AGENT_TYPE" \
+            --jvm-name "$JVM_NAME" \
+            --jmx-params "$JMX_PARAMS" \
+            --metrics-receiver "$METRICS_RECEIVER" \
+            --tracing-receiver "$TRACE_RECEIVER" \
+            --region "$REGION" \
+            --jmx-host "$JMX_HOST" \
+            --jmx-port "$JMX_PORT" \
+            --jmx-pass-file "$JMX_PASS_FILE" \
+            --jmx-trust-store "$JMX_TRUSTSTORE" \
+            --jmx-trust-store-pass "$JMX_TRUSTSTORE_PASS" \
+            "$EXTRA_PARAMS"
 
          if [ $? -ne 0 ]; then
             exit 1

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -45,7 +45,7 @@ case $1 in
             --jmx-pass-file "$JMX_PASS_FILE" \
             --jmx-trust-store "$JMX_TRUSTSTORE" \
             --jmx-trust-store-pass "$JMX_TRUSTSTORE_PASS" \
-            "$EXTRA_PARAMS"
+            $EXTRA_PARAMS
 
          if [ $? -ne 0 ]; then
             exit 1

--- a/spm-monitor-haproxy/src/main/java/com/sematext/spm/client/haproxy/collector/HAProxyStatsCollector.java
+++ b/spm-monitor-haproxy/src/main/java/com/sematext/spm/client/haproxy/collector/HAProxyStatsCollector.java
@@ -100,7 +100,7 @@ public class HAProxyStatsCollector extends MultipleStatsCollector<HAProxyStats> 
     statValues.getTags().put("haproxy.type", stats.getType());
     statValues.getTags().put("haproxy.service", stats.getServiceName());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("haproxy");

--- a/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisDbStatsCollector.java
+++ b/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisDbStatsCollector.java
@@ -100,7 +100,7 @@ public class RedisDbStatsCollector extends MultipleStatsCollector<Tuple<String, 
     statValues.setTags(new UnifiedMap<String, String>());
     statValues.getTags().put("redis.db", stats.getFirst());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("redis");

--- a/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisStatsCollector.java
+++ b/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisStatsCollector.java
@@ -106,7 +106,7 @@ public class RedisStatsCollector extends SingleStatsCollector {
 
     statValues.setTags(new UnifiedMap<String, String>());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("redis");

--- a/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormBoltInputStatsCollector.java
+++ b/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormBoltInputStatsCollector.java
@@ -127,7 +127,7 @@ public class StormBoltInputStatsCollector extends MultipleStatsCollector<Tuple<L
     statValues.getTags().put("storm.bolt.executor.id", stats.getFirst().get(3));
     statValues.getTags().put("storm.bolt.stream.component", stats.getFirst().get(4));
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("storm");

--- a/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormBoltOutputStatsCollector.java
+++ b/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormBoltOutputStatsCollector.java
@@ -120,7 +120,7 @@ public class StormBoltOutputStatsCollector extends MultipleStatsCollector<Tuple<
     statValues.getTags().put("storm.bolt.stream", stats.getFirst().get(2));
     statValues.getTags().put("storm.bolt.executor.id", stats.getFirst().get(3));
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("storm");

--- a/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormClusterStatsCollector.java
+++ b/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormClusterStatsCollector.java
@@ -87,7 +87,7 @@ public class StormClusterStatsCollector extends SingleStatsCollector implements 
 
     statValues.setTags(new UnifiedMap<String, String>());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("storm");

--- a/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormSpoutOutputStatsCollector.java
+++ b/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormSpoutOutputStatsCollector.java
@@ -125,7 +125,7 @@ public class StormSpoutOutputStatsCollector extends MultipleStatsCollector<Tuple
     statValues.getTags().put("storm.spout", stats.getFirst().get(1));
     statValues.getTags().put("storm.spout.stream", stats.getFirst().get(2));
     statValues.getTags().put("storm.spout.executor.id", stats.getFirst().get(3));
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("storm");

--- a/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormSupervisorStatsCollector.java
+++ b/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormSupervisorStatsCollector.java
@@ -122,7 +122,7 @@ public class StormSupervisorStatsCollector extends MultipleStatsCollector<Tuple<
     statValues.getTags().put("storm.supervisor.id", stats.getFirst());
     statValues.getTags().put("storm.supervisor.host", String.valueOf(stats.getSecond().get(0)));
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("storm");

--- a/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormTopologyStatsCollector.java
+++ b/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormTopologyStatsCollector.java
@@ -137,7 +137,7 @@ public class StormTopologyStatsCollector extends MultipleStatsCollector<Tuple<St
     statValues.getTags().put("storm.topology", stats.getFirst());
     statValues.getTags().put("storm.topology.status", String.valueOf(stats.getSecond().get(0)));
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("storm");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
@@ -46,7 +46,7 @@ public abstract class GenericExtractor<S extends StatsExtractorConfig<O>, T exte
   public static final String CONTAINER_HOST_HOSTNAME_TAG = "container.host.hostname";
   public static final String CONTAINER_NAME_TAG = "container.name";
   public static final String CONTAINER_ID_TAG = "container.id";
-  public static final String CONTAINER_IMAGE_TAG = "container.image";
+  public static final String CONTAINER_IMAGE_TAG = "container.image.name";
   public static final String K8S_POD_NAME_TAG = "kubernetes.pod.name";
   public static final String K8S_NAMESPACE_ID_TAG = "kubernetes.namespace";
   public static final String K8S_CLUSTER_TAG = "kubernetes.cluster.name";

--- a/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
@@ -44,6 +44,12 @@ public abstract class GenericExtractor<S extends StatsExtractorConfig<O>, T exte
   public static final String JVM_NAME_TAG = "jvm";
   public static final String CONTAINER_HOSTNAME_TAG = "container.hostname";
   public static final String CONTAINER_HOST_HOSTNAME_TAG = "container.host.hostname";
+  public static final String CONTAINER_NAME_TAG = "container.name";
+  public static final String CONTAINER_ID_TAG = "container.id";
+  public static final String CONTAINER_IMAGE_TAG = "container.image";
+  public static final String K8S_POD_NAME_TAG = "kubernetes.pod.name";
+  public static final String K8S_NAMESPACE_ID_TAG = "kubernetes.namespace";
+  public static final String K8S_CLUSTER_TAG = "kubernetes.cluster.name";
   public static final String OS_HOST_TAG = "os.host";
 
   private static final Log LOG = LogFactory.getLog(GenericExtractor.class);
@@ -259,6 +265,37 @@ public abstract class GenericExtractor<S extends StatsExtractorConfig<O>, T exte
     if (containerHostname != null) {
       partlyResolvedObservationConfigTags.put(CONTAINER_HOSTNAME_TAG, containerHostname);
     }
+
+    if (SenderUtil.isInContainer()) {
+      String containerName = SenderUtil.getContainerName();
+      if (containerName != null) {
+        partlyResolvedObservationConfigTags.put(CONTAINER_NAME_TAG, containerName);
+      }
+      String containerId = SenderUtil.getContainerId();
+      if (containerId != null) {
+        partlyResolvedObservationConfigTags.put(CONTAINER_ID_TAG, containerId);
+      }
+      String containerImage = SenderUtil.getContainerImage();
+      if (containerImage != null) {
+        partlyResolvedObservationConfigTags.put(CONTAINER_IMAGE_TAG, containerImage);
+      }
+    }
+
+    if (SenderUtil.isInKubernetes()) {
+      String podName = SenderUtil.getK8sPodName();
+      if (podName != null) {
+        partlyResolvedObservationConfigTags.put(K8S_POD_NAME_TAG, podName);
+      }
+      String namespace = SenderUtil.getK8sNamespace();
+      if (namespace != null) {
+        partlyResolvedObservationConfigTags.put(K8S_NAMESPACE_ID_TAG, namespace);
+      }
+      String cluster = SenderUtil.getK8sCluster();
+      if (cluster != null) {
+        partlyResolvedObservationConfigTags.put(K8S_CLUSTER_TAG, cluster);
+      }
+    }
+
     partlyResolvedObservationConfigTagsAsString = partlyResolvedObservationConfigTags.toString();
   }
 

--- a/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/GenericExtractor.java
@@ -261,7 +261,7 @@ public abstract class GenericExtractor<S extends StatsExtractorConfig<O>, T exte
     if (dockerHostname != null) {
       partlyResolvedObservationConfigTags.put(CONTAINER_HOST_HOSTNAME_TAG, dockerHostname);
     }
-    String containerHostname = MonitorUtil.getContainerHostname(monitorPropertiesFile, monitorProperties);
+    String containerHostname = MonitorUtil.getContainerHostname(monitorPropertiesFile, monitorProperties, SenderUtil.isInContainer());
     if (containerHostname != null) {
       partlyResolvedObservationConfigTags.put(CONTAINER_HOSTNAME_TAG, containerHostname);
     }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/HeartbeatStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/HeartbeatStatsCollector.java
@@ -93,7 +93,7 @@ public class HeartbeatStatsCollector extends MultipleStatsCollector<Integer> {
     // CollectionStats.CURRENT_RUN_GATHERED_LINES is on the level of whole agent
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("heartbeat");      

--- a/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
@@ -47,7 +47,7 @@ public final class StatValuesHelper {
         statValues.getTags().put("container.hostname", containerHostname);
       }
     } catch (Throwable thr) {
-      LOG.warn("Can't resolve container.hostname value, leaving empty", thr);
+      LOG.warn("Can't resolve container.hostname value, skipping", thr);
     }
 
     try {
@@ -69,6 +69,27 @@ public final class StatValuesHelper {
       }
     } catch (Throwable thr) {
       LOG.warn("Can't resolve container tags, leaving empty", thr);
+    }
+
+    try {
+      if (SenderUtil.isInKubernetes()) {
+        String podName = SenderUtil.getK8sPodName();
+        if (podName != null) {
+          statValues.getTags().put("kubernetes.pod.name", podName);
+        }
+
+        String namespace = SenderUtil.getK8sNamespace();
+        if (namespace != null) {
+          statValues.getTags().put("kubernetes.namespace", namespace);
+        }
+
+        String cluster = SenderUtil.getK8sCluster();
+        if (cluster != null) {
+          statValues.getTags().put("kubernetes.cluster.name", cluster);
+        }
+      }
+    } catch (Throwable thr) {
+      LOG.warn("Can't resolve kubernetes tags, skipping", thr);
     }
   }
 }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
@@ -64,7 +64,7 @@ public final class StatValuesHelper {
 
         String containerImage = SenderUtil.getContainerImage();
         if (containerImage != null) {
-          statValues.getTags().put("container.image", containerImage);
+          statValues.getTags().put("container.image.name", containerImage);
         }
       }
     } catch (Throwable thr) {

--- a/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
@@ -92,4 +92,29 @@ public final class StatValuesHelper {
       LOG.warn("Can't resolve kubernetes tags, skipping", thr);
     }
   }
+
+  public static void fillEnvTagsForTagAliases(StatValues statValues) {
+    try {
+      statValues.getTags().put("os.host", SenderUtil.calculateHostParameterValue());
+    } catch (Throwable thr) {
+      LOG.warn("Can't resolve os.host value, setting to unknown", thr);
+      statValues.getTags().put("os.host", "unknown");
+    }
+
+    String dockerHostname = SenderUtil.getDockerHostname();
+    if (dockerHostname != null) {
+      statValues.getTags().put("container.host.hostname", dockerHostname);
+    }
+
+    try {
+      if (SenderUtil.isInContainer()) {
+        String containerId = SenderUtil.getContainerId();
+        if (containerId != null) {
+          statValues.getTags().put("container.id", containerId);
+        }
+      }
+    } catch (Throwable thr) {
+      LOG.warn("Can't resolve container id tag, leaving empty", thr);
+    }
+  }
 }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
@@ -42,7 +42,7 @@ public final class StatValuesHelper {
       statValues.getTags().put("container.host.hostname", dockerHostname);
     }
     try {
-      String containerHostname = MonitorUtil.getContainerHostname(propsFile);
+      String containerHostname = MonitorUtil.getContainerHostname(propsFile, SenderUtil.isInContainer());
       if (containerHostname != null) {
         statValues.getTags().put("container.hostname", containerHostname);
       }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/StatValuesHelper.java
@@ -29,7 +29,7 @@ public final class StatValuesHelper {
   private StatValuesHelper() {
   }
 
-  public static void fillHostTags(StatValues statValues, File propsFile) {
+  public static void fillEnvTags(StatValues statValues, File propsFile) {
     try {
       statValues.getTags().put("os.host", SenderUtil.calculateHostParameterValue());
     } catch (Throwable thr) {
@@ -48,6 +48,27 @@ public final class StatValuesHelper {
       }
     } catch (Throwable thr) {
       LOG.warn("Can't resolve container.hostname value, leaving empty", thr);
+    }
+
+    try {
+      if (SenderUtil.isInContainer()) {
+        String containerName = SenderUtil.getContainerName();
+        if (containerName != null) {
+          statValues.getTags().put("container.name", containerName);
+        }
+
+        String containerId = SenderUtil.getContainerId();
+        if (containerId != null) {
+          statValues.getTags().put("container.id", containerId);
+        }
+
+        String containerImage = SenderUtil.getContainerImage();
+        if (containerImage != null) {
+          statValues.getTags().put("container.image", containerImage);
+        }
+      }
+    } catch (Throwable thr) {
+      LOG.warn("Can't resolve container tags, leaving empty", thr);
     }
   }
 }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmGcStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmGcStatsCollector.java
@@ -65,7 +65,7 @@ public class JvmGcStatsCollector extends SingleStatsCollector {
     statValues.getTags().put("jvm.gc", gcStats.getGcName());
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("jvm");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmMemoryPoolStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmMemoryPoolStatsCollector.java
@@ -65,7 +65,7 @@ public class JvmMemoryPoolStatsCollector extends SingleStatsCollector {
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
     statValues.getTags().put("jvm.memory.pool", stats.getPoolName());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("jvm");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmMemoryStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmMemoryStatsCollector.java
@@ -64,7 +64,7 @@ public class JvmMemoryStatsCollector extends SingleStatsCollector {
     statValues.setTags(new UnifiedMap<String, String>());
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("jvm");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmNotifBasedGcStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmNotifBasedGcStatsCollector.java
@@ -105,7 +105,7 @@ public class JvmNotifBasedGcStatsCollector
       statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
       statValues.getTags().put("jvm.gc", protoStats.getGcName());
 
-      StatValuesHelper.fillHostTags(statValues, propsFile);
+      StatValuesHelper.fillEnvTags(statValues, propsFile);
       statValues.setTimestamp(protoStats.getTimestamp());
       statValues.setAppToken(appToken);
       statValues.setMetricNamespace("jvm");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmOsStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmOsStatsCollector.java
@@ -90,7 +90,7 @@ public class JvmOsStatsCollector extends SingleStatsCollector {
     statValues.setTags(new UnifiedMap<String, String>());
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("jvm");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmThreadStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/jvm/JvmThreadStatsCollector.java
@@ -66,7 +66,7 @@ public class JvmThreadStatsCollector extends SingleStatsCollector {
     statValues.setTags(new UnifiedMap<String, String>());
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("jvm");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tag/MultipleTagAliasCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tag/MultipleTagAliasCollector.java
@@ -79,7 +79,7 @@ public class MultipleTagAliasCollector extends MultipleStatsCollector<String> {
     statValues.getMetrics().put(tag.substring(0, tag.indexOf(":")), tag.substring(tag.indexOf(":") + 1));
     statValues.setTags(new UnifiedMap<String, String>());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     if (jvmNameForTags != null) {
       statValues.getTags().put("jvm", jvmNameForTags);
     }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tag/MultipleTagAliasCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tag/MultipleTagAliasCollector.java
@@ -79,7 +79,7 @@ public class MultipleTagAliasCollector extends MultipleStatsCollector<String> {
     statValues.getMetrics().put(tag.substring(0, tag.indexOf(":")), tag.substring(tag.indexOf(":") + 1));
     statValues.setTags(new UnifiedMap<String, String>());
 
-    StatValuesHelper.fillEnvTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTagsForTagAliases(statValues);
     if (jvmNameForTags != null) {
       statValues.getTags().put("jvm", jvmNameForTags);
     }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingCrossAppCallStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingCrossAppCallStatsCollector.java
@@ -72,7 +72,7 @@ public class TracingCrossAppCallStatsCollector extends MultipleStatsCollector<Cr
     statValues.getTags().put("tracing.cross.app.call.tag", call.tag());
     statValues.getTags().put("tracing.cross.app.call.request", call.request());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("tracing");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingDatabaseOperationStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingDatabaseOperationStatsCollector.java
@@ -70,7 +70,7 @@ public class TracingDatabaseOperationStatsCollector extends MultipleStatsCollect
     statValues.getTags().put("tracing.db.operation.db", s.getId().getDatabase());
     statValues.getTags().put("tracing.db.operation.operation", s.getId().getOperation());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("tracing");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingExternalCallStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingExternalCallStatsCollector.java
@@ -69,7 +69,7 @@ public class TracingExternalCallStatsCollector extends MultipleStatsCollector<Ex
     statValues.getTags().put("tracing.external.call.destination", call.dstHostname());
     statValues.getTags().put("tracing.external.call.tag", call.tag());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("tracing");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingReqCompStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingReqCompStatsCollector.java
@@ -69,7 +69,7 @@ public class TracingReqCompStatsCollector extends MultipleStatsCollector<Request
     statValues.getTags().put("tracing.request", s.getId().getRequest());
     statValues.getTags().put("tracing.component", s.getId().getComponent());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("tracing");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingReqErrorsStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingReqErrorsStatsCollector.java
@@ -70,7 +70,7 @@ public class TracingReqErrorsStatsCollector extends MultipleStatsCollector<Reque
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
     statValues.getTags().put("tracing.request", metric.getId());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("tracing");

--- a/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingReqStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/tracing/TracingReqStatsCollector.java
@@ -98,7 +98,7 @@ public class TracingReqStatsCollector extends MultipleStatsCollector<RequestMetr
     statValues.getTags().put(GenericExtractor.JVM_NAME_TAG, finalJvmName);
     statValues.getTags().put("tracing.request", s.getId());
 
-    StatValuesHelper.fillHostTags(statValues, propsFile);
+    StatValuesHelper.fillEnvTags(statValues, propsFile);
     statValues.setTimestamp(System.currentTimeMillis());
     statValues.setAppToken(appToken);
     statValues.setMetricNamespace("tracing");

--- a/spm-sender/src/main/java/com/sematext/spm/client/sender/SenderUtil.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/sender/SenderUtil.java
@@ -155,7 +155,7 @@ public final class SenderUtil {
         containerName == null &&
         containerId == null &&
         containerImage == null) {
-      return; // not container setup
+      // not container setup
     } else {
       checkEnvForNull(CONTAINER_HOST_HOSTNAME_ENV_NAME, containerHostHostName);
       checkEnvForNull(CONTAINER_NAME_ENV_NAME, containerName);
@@ -172,7 +172,7 @@ public final class SenderUtil {
     if (k8sPodName == null &&
         k8sNamespace == null &&
         k8sCluster == null) {
-      return; // not k8s setup
+      // not k8s setup
     } else {
       checkEnvForNull(K8S_POD_ENV_NAME, k8sPodName);
       checkEnvForNull(K8S_NAMESPACE_ENV_NAME, k8sNamespace);
@@ -183,7 +183,7 @@ public final class SenderUtil {
 
   private static void checkEnvForNull(String name, String value) {
     if (value == null) {
-      throw new IllegalArgumentException(String.format("Agent seems to be running in container, but %s is not set", name));
+      throw new IllegalArgumentException(String.format("Agent seems to be running in container/kubernetes, but %s is not set", name));
     }
   }
 

--- a/spm-sender/src/main/java/com/sematext/spm/client/sender/bootstrap/SenderFlumeAgentFactory.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/sender/bootstrap/SenderFlumeAgentFactory.java
@@ -202,7 +202,7 @@ public final class SenderFlumeAgentFactory {
         .calculateHostParameterValue());
     properties.put(CustomElasticSearchRestClient.URL_PARAM_DOCKER_HOSTNAME, SenderUtil.getDockerHostname());
     properties.put(CustomElasticSearchRestClient.URL_PARAM_CONTAINER_HOSTNAME, MonitorUtil
-        .getContainerHostname(monitorPropertiesFile, monitorProperties));
+        .getContainerHostname(monitorPropertiesFile, monitorProperties, SenderUtil.isInContainer()));
 
     // properties.put(CustomElasticSearchRestClient.URL_PARAM_VERSION, MonitorAgent.class.getPackage().getSpecificationVersion());
     properties.put(CustomElasticSearchRestClient.URL_PARAM_VERSION, SenderFlumeAgentFactory.class.getPackage()


### PR DESCRIPTION
* Update AA to send container name, id, image, hostname, host.hostname and kubernetes pod, namespace, and cluster tags if present as physical tags with all metrics
* The above tags can be passed as env vars to AA container image from STA or during manual startup. AA expects either all container tags or all kubernetes tags to be present. else will throw an error and won't proceed
* when these params are set AA assumes it is running in a container or k8s env
* The old logic of .docker file will continue to work with nodejs based disco.
* Adjusted container.hostname to be read from any app config param which ends with `_HOST_PORT`

Tested with normal process based install (should not send any of the above tags ) and from STA auto disco. Tested k8s by manually passing the env vars but not in actual k8s setup

Sample output:

The physical hostname is `optimus-prime` and AA is monitoring ES docker container

```
tag.alias,token=df372e3b-7e40-4d05-8ca3-b6a8f8905485,container.id=b58e4f3c7ebfa51b585f64b1fcf331e809fb43cdade113a53bd559fd22159684,container.host.hostname=optimus-prime,container.image=docker.elastic.co/elasticsearch/elasticsearch:6.2.4,os.host=optimus-prime,container.name=brave_brahmagupta,jvm=brave_brahmagupta,tag.alias.type=config,container.hostname=172.17.0.2 appType="elasticsearch" 1559814609209000000

jvm,token=df372e3b-7e40-4d05-8ca3-b6a8f8905485,jvm=brave_brahmagupta,es.node.id=JUdHzleNRsWUxVfII2fNqw,container.hostname=172.17.0.2,container.name=brave_brahmagupta,container.host.hostname=optimus-prime,os.host=optimus-prime,container.image=docker.elastic.co/elasticsearch/elasticsearch:6.2.4,es.node=JUdHzle,container.id=b58e4f3c7ebfa51b585f64b1fcf331e809fb43cdade113a53bd559fd22159684 threads.peak=32i,threads=32i,files.open=460i,files.max=1048576i 1559814612238000000

heartbeat,token=df372e3b-7e40-4d05-8ca3-b6a8f8905485,container.id=b58e4f3c7ebfa51b585f64b1fcf331e809fb43cdade113a53bd559fd22159684,container.host.hostname=optimus-prime,container.image=docker.elastic.co/elasticsearch/elasticsearch:6.2.4,os.host=optimus-prime,jvm=brave_brahmagupta,container.name=brave_brahmagupta,container.hostname=172.17.0.2 alive=1i 1559814612238000000
```

