### PR TITLE
SC-5584: MariaDB monitoring not working on new WWW

### DIFF
--- a/docs/metrics-yaml-format.md
+++ b/docs/metrics-yaml-format.md
@@ -26,6 +26,9 @@ observation:
     is supported for `db` and `json` types.
     * DB data source
         * `query`: The SQL query be executed to collect metrics.
+        * `dbDriver`: List of DB URL (`url`) and driver class (`clazz`) pairs. To be used when multiple drivers are 
+        possible for an integration. For example, MySQL & MariaDB. The agent will load each class in the list and 
+        use the pair for which it can load the class.
         * `dbUrl`: The DB Connection string. e.g. `jdbc:postgresql://${POSTGRESQL_HOST_PORT}/{POSTGRESQL_DB}` where
         `POSTGRESQL_HOST_PORT` is placeholder for the variable passed from `setup-spm` script. It is recommended to name
         the variable using `<INTEGRATION_NAME>_HOST_PORT` format.

--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/DataConfig.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/DataConfig.java
@@ -22,7 +22,7 @@ package com.sematext.spm.client.config;
 public class DataConfig {
   private String query;
   private String dbUrl;
-  private String dbDriverClass;
+  private String[] dbDriverClass;
   private String dbUser;
   private String dbPassword;
   private String dbAdditionalConnectionParams;
@@ -52,11 +52,11 @@ public class DataConfig {
     this.dbUrl = dbUrl;
   }
 
-  public String getDbDriverClass() {
+  public String[] getDbDriverClass() {
     return dbDriverClass;
   }
 
-  public void setDbDriverClass(String dbDriverClass) {
+  public void setDbDriverClass(String[] dbDriverClass) {
     this.dbDriverClass = dbDriverClass;
   }
 

--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/DataConfig.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/DataConfig.java
@@ -19,14 +19,17 @@
  */
 package com.sematext.spm.client.config;
 
+import java.util.List;
+
 public class DataConfig {
   private String query;
   private String dbUrl;
-  private String[] dbDriverClass;
+  private String dbDriverClass;
   private String dbUser;
   private String dbPassword;
   private String dbAdditionalConnectionParams;
   private boolean dbVerticalModel = false;
+  private List<DbDriverConfig> dbDriver;
 
   private String url;
   private String server;
@@ -52,11 +55,11 @@ public class DataConfig {
     this.dbUrl = dbUrl;
   }
 
-  public String[] getDbDriverClass() {
+  public String getDbDriverClass() {
     return dbDriverClass;
   }
 
-  public void setDbDriverClass(String[] dbDriverClass) {
+  public void setDbDriverClass(String dbDriverClass) {
     this.dbDriverClass = dbDriverClass;
   }
 
@@ -165,5 +168,13 @@ public class DataConfig {
 
   public void setJsonHandlerClass(String jsonHandlerClass) {
     this.jsonHandlerClass = jsonHandlerClass;
+  }
+
+  public List<DbDriverConfig> getDbDriver() {
+    return dbDriver;
+  }
+
+  public void setDbDriver(List<DbDriverConfig> dbDriver) {
+    this.dbDriver = dbDriver;
   }
 }

--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/DbDriverConfig.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/config/DbDriverConfig.java
@@ -1,0 +1,22 @@
+package com.sematext.spm.client.config;
+
+public class DbDriverConfig {
+  private String url;
+  private String clazz;
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getClazz() {
+    return clazz;
+  }
+
+  public void setClazz(String clazz) {
+    this.clazz = clazz;
+  }
+}

--- a/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractorConfig.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractorConfig.java
@@ -32,7 +32,7 @@ import com.sematext.spm.client.config.ObservationDefinitionConfig;
 public class DbStatsExtractorConfig extends StatsExtractorConfig<DbObservation> {
   private String dataRequestQuery;
   private String dbUrl;
-  private String dbDriverClass;
+  private String[] dbDriverClass;
   private String dbUser;
   private String dbPassword;
   private String dbAdditionalConnectionParams;
@@ -107,7 +107,7 @@ public class DbStatsExtractorConfig extends StatsExtractorConfig<DbObservation> 
     return dbUrl;
   }
 
-  public String getDbDriverClass() {
+  public String[] getDbDriverClass() {
     return dbDriverClass;
   }
 


### PR DESCRIPTION
Added new dbDriver property which takes a list of url & clazz. Updated MySQL YAMLs to specify both MariaDB and MySQL driver properties and verified the same. Also, verify the old properties with CH.

```yml
  dbDriver:
    - url: jdbc:mysql://${SPM_MONITOR_MYSQL_DB_HOST_PORT}
      clazz: com.mysql.jdbc.Driver
    - url: jdbc:mariadb://${SPM_MONITOR_MYSQL_DB_HOST_PORT}
      clazz: org.mariadb.jdbc.Driver
```