### PR TITLE
Support for st attribute prefix

### DIFF
--- a/spm-monitor-generic/src/main/java/com/sematext/spm/client/GenericStatsCollectorsFactory.java
+++ b/spm-monitor-generic/src/main/java/com/sematext/spm/client/GenericStatsCollectorsFactory.java
@@ -658,6 +658,8 @@ public class GenericStatsCollectorsFactory extends StatsCollectorsFactory<StatsC
     String fileKey = configFile.getAbsolutePath();
 
     // replace all monitor properties placeholders with real values from properties file
+    // NOTE: assumption is that it is ok if behavior will be undefined when two props have the same variants (ST_PROP
+    // and SPM_PROP) because order of execution would affect the end result 
     for (Object property : monitorProperties.keySet()) {
       String propertyValue = MonitorUtil.stripQuotes(monitorProperties.getProperty(String.valueOf(property), "").trim())
           .trim();

--- a/spm-monitor-generic/src/main/java/com/sematext/spm/client/GenericStatsCollectorsFactory.java
+++ b/spm-monitor-generic/src/main/java/com/sematext/spm/client/GenericStatsCollectorsFactory.java
@@ -727,12 +727,12 @@ public class GenericStatsCollectorsFactory extends StatsCollectorsFactory<StatsC
       
       if (configPropertyName.startsWith("ST_")) {
         propertyVariants.add(configPropertyName);
-        propertyVariants.add(configPropertyName.replace("ST_", "SPM_"));
-        propertyVariants.add(configPropertyName.replace("ST_", ""));
+        propertyVariants.add(configPropertyName.replaceFirst("ST_", "SPM_"));
+        propertyVariants.add(configPropertyName.replaceFirst("ST_", ""));
       } else if (configPropertyName.startsWith("SPM_")) {
-        propertyVariants.add(configPropertyName.replace("SPM_", "ST_"));
+        propertyVariants.add(configPropertyName.replaceFirst("SPM_", "ST_"));
         propertyVariants.add(configPropertyName);
-        propertyVariants.add(configPropertyName.replace("SPM_", ""));
+        propertyVariants.add(configPropertyName.replaceFirst("SPM_", ""));
       } else {
         propertyVariants.add("ST_" + configPropertyName);
         propertyVariants.add("SPM_" + configPropertyName);

--- a/spm-monitor-generic/src/test/java/com/sematext/spm/client/GenericStatsCollectorsFactoryTest.java
+++ b/spm-monitor-generic/src/test/java/com/sematext/spm/client/GenericStatsCollectorsFactoryTest.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -154,5 +155,27 @@ public class GenericStatsCollectorsFactoryTest {
     f.resolveAttributePlaceholders(p, m, allTags);
     Assert.assertEquals(allTags.get("topic"), "mytopic");
     Assert.assertEquals(allTags.get("partition"), "1");
+  }
+  
+  @Test
+  public void testGetPropertyVariants() {
+    GenericStatsCollectorsFactory f = new GenericStatsCollectorsFactory();
+    List<String> variants = f.getPropertyVariants("SPM_SOME_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
+    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
+    Assert.assertEquals("SOME_PROP", variants.get(2));
+
+    variants = f.getPropertyVariants("ST_SOME_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
+    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
+    Assert.assertEquals("SOME_PROP", variants.get(2));
+
+    variants = f.getPropertyVariants("SOME_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
+    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
+    Assert.assertEquals("SOME_PROP", variants.get(2));
   }
 }

--- a/spm-monitor-generic/src/test/java/com/sematext/spm/client/GenericStatsCollectorsFactoryTest.java
+++ b/spm-monitor-generic/src/test/java/com/sematext/spm/client/GenericStatsCollectorsFactoryTest.java
@@ -177,5 +177,12 @@ public class GenericStatsCollectorsFactoryTest {
     Assert.assertEquals("ST_SOME_PROP", variants.get(0));
     Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
     Assert.assertEquals("SOME_PROP", variants.get(2));
+    
+    variants = f.getPropertyVariants("ST_TEST_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_TEST_PROP", variants.get(0));
+    Assert.assertEquals("SPM_TEST_PROP", variants.get(1));
+    Assert.assertEquals("TEST_PROP", variants.get(2));
+
   }
 }


### PR DESCRIPTION
Inject all variants of each attribute into yaml config placeholders

Due to future renaming of attributes (adding ST_ prefix instead of SPM_ or no prefix at all), agent should try all variants of each property (even the ones already in new format).