### PR TITLE
refactored new attrib logic a bit, added support for redis/haproxy/storm

### DIFF
--- a/spm-monitor-generic/src/main/java/com/sematext/spm/client/GenericStatsCollectorsFactory.java
+++ b/spm-monitor-generic/src/main/java/com/sematext/spm/client/GenericStatsCollectorsFactory.java
@@ -649,8 +649,6 @@ public class GenericStatsCollectorsFactory extends StatsCollectorsFactory<StatsC
 
   private static final Map<String, Long> FILE_TO_LAST_MODIFIED = new HashMap<String, Long>();
   private static final Map<String, StatsExtractorConfig<?>> FILE_TO_LAST_CREATED_CONFIG_BEAN_MAP = new HashMap<String, StatsExtractorConfig<?>>();
-  
-  private static final Map<String, List<String>> PROPERTY_VARIANTS = new HashMap<String, List<String>>();
 
   private StatsExtractorConfig<?> getStatsExtractorConfig(File configFile, String configFileContent,
                                                           Properties monitorProperties, MonitorConfig monitorConfig)
@@ -664,7 +662,7 @@ public class GenericStatsCollectorsFactory extends StatsCollectorsFactory<StatsC
       String propertyValue = MonitorUtil.stripQuotes(monitorProperties.getProperty(String.valueOf(property), "").trim())
           .trim();
 
-      for (String propertyNameVariant : getPropertyVariants(String.valueOf(property))) {
+      for (String propertyNameVariant : MonitorUtil.getPropertyVariants(String.valueOf(property))) {
         String propertyNameVariantPlaceholder = "${" + String.valueOf(propertyNameVariant) + "}";
         configFileContent = configFileContent.replace(propertyNameVariantPlaceholder, propertyValue);
       }
@@ -717,32 +715,6 @@ public class GenericStatsCollectorsFactory extends StatsCollectorsFactory<StatsC
       FILE_TO_LAST_CREATED_CONFIG_BEAN_MAP.put(fileKey, newConfig);
 
       return newConfig;
-    }
-  }
-
-  // should return the variants in order: ST_*, SPM_*, *
-  protected List<String> getPropertyVariants(String configPropertyName) {
-    if (PROPERTY_VARIANTS.containsKey(configPropertyName)) {
-      return PROPERTY_VARIANTS.get(configPropertyName);
-    } else {
-      List<String> propertyVariants = new ArrayList<String>();
-      
-      if (configPropertyName.startsWith("ST_")) {
-        propertyVariants.add(configPropertyName);
-        propertyVariants.add(configPropertyName.replaceFirst("ST_", "SPM_"));
-        propertyVariants.add(configPropertyName.replaceFirst("ST_", ""));
-      } else if (configPropertyName.startsWith("SPM_")) {
-        propertyVariants.add(configPropertyName.replaceFirst("SPM_", "ST_"));
-        propertyVariants.add(configPropertyName);
-        propertyVariants.add(configPropertyName.replaceFirst("SPM_", ""));
-      } else {
-        propertyVariants.add("ST_" + configPropertyName);
-        propertyVariants.add("SPM_" + configPropertyName);
-        propertyVariants.add(configPropertyName);
-      }
-      
-      PROPERTY_VARIANTS.put(configPropertyName, propertyVariants);
-      return propertyVariants;
     }
   }
 

--- a/spm-monitor-generic/src/test/java/com/sematext/spm/client/GenericStatsCollectorsFactoryTest.java
+++ b/spm-monitor-generic/src/test/java/com/sematext/spm/client/GenericStatsCollectorsFactoryTest.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -155,34 +154,5 @@ public class GenericStatsCollectorsFactoryTest {
     f.resolveAttributePlaceholders(p, m, allTags);
     Assert.assertEquals(allTags.get("topic"), "mytopic");
     Assert.assertEquals(allTags.get("partition"), "1");
-  }
-  
-  @Test
-  public void testGetPropertyVariants() {
-    GenericStatsCollectorsFactory f = new GenericStatsCollectorsFactory();
-    List<String> variants = f.getPropertyVariants("SPM_SOME_PROP");
-    Assert.assertEquals(3, variants.size());
-    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
-    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
-    Assert.assertEquals("SOME_PROP", variants.get(2));
-
-    variants = f.getPropertyVariants("ST_SOME_PROP");
-    Assert.assertEquals(3, variants.size());
-    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
-    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
-    Assert.assertEquals("SOME_PROP", variants.get(2));
-
-    variants = f.getPropertyVariants("SOME_PROP");
-    Assert.assertEquals(3, variants.size());
-    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
-    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
-    Assert.assertEquals("SOME_PROP", variants.get(2));
-    
-    variants = f.getPropertyVariants("ST_TEST_PROP");
-    Assert.assertEquals(3, variants.size());
-    Assert.assertEquals("ST_TEST_PROP", variants.get(0));
-    Assert.assertEquals("SPM_TEST_PROP", variants.get(1));
-    Assert.assertEquals("TEST_PROP", variants.get(2));
-
   }
 }

--- a/spm-monitor-haproxy/src/main/java/com/sematext/spm/client/haproxy/factory/HAProxyStatsFactory.java
+++ b/spm-monitor-haproxy/src/main/java/com/sematext/spm/client/haproxy/factory/HAProxyStatsFactory.java
@@ -53,13 +53,12 @@ public class HAProxyStatsFactory extends StatsCollectorsFactory<StatsCollector<?
                                                              List<? extends StatsCollector<?>> currentCollectors,
                                                              final MonitorConfig monitorConfig) {
     if (collectors == null) {
-      String statsUrl = MonitorUtil.stripQuotes(monitorProperties
-                                                    .getProperty("SPM_MONITOR_HAPROXY_STATS_URL", "http://localhost/haproxy_stats;csv")
-                                                    .trim()).trim();
-      String user = MonitorUtil.stripQuotes(monitorProperties.getProperty("SPM_MONITOR_HAPROXY_USER", "").trim())
-          .trim();
-      String password = MonitorUtil
-          .stripQuotesIfEnclosed(monitorProperties.getProperty("SPM_MONITOR_HAPROXY_PASSWORD", ""));
+      String statsUrl = MonitorUtil.stripQuotes(MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties,
+          "SPM_MONITOR_HAPROXY_STATS_URL", "http://localhost/haproxy_stats;csv").trim()).trim();
+      String user = MonitorUtil.stripQuotes(MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties,
+          "SPM_MONITOR_HAPROXY_USER", "").trim()).trim();
+      String password = MonitorUtil.stripQuotesIfEnclosed(MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties,
+          "SPM_MONITOR_HAPROXY_PASSWORD", ""));
 
       HttpDataSourceAuthentication auth = null;
       if (user != null && password != null) {

--- a/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisStatsCollectorsFactory.java
+++ b/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisStatsCollectorsFactory.java
@@ -54,9 +54,12 @@ public class RedisStatsCollectorsFactory extends StatsCollectorsFactory<StatsCol
       throws StatsCollectorBadConfigurationException {
 
     Integer redisPort = null;
-    String hostParam = MonitorUtil.stripQuotes(monitorProperties.getProperty("REDIS_HOST", "localhost").trim()).trim();
-    String passwordParam = MonitorUtil.stripQuotesIfEnclosed(monitorProperties.getProperty("REDIS_PASSWORD", ""));
-    String portParam = MonitorUtil.stripQuotes(monitorProperties.getProperty("REDIS_PORT", "6379").trim()).trim();
+    String hostParam = MonitorUtil.stripQuotes(
+        MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties, "REDIS_HOST", "localhost").trim()).trim();
+    String passwordParam = MonitorUtil.stripQuotesIfEnclosed(
+        MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties, "REDIS_PASSWORD", ""));
+    String portParam = MonitorUtil.stripQuotes(
+        MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties, "REDIS_PORT", "6379").trim()).trim();
 
     if (portParam != null && !portParam.isEmpty()) {
       try {

--- a/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormNimbusStatsCollectorsFactory.java
+++ b/spm-monitor-storm/src/main/java/com/sematext/spm/client/storm/StormNimbusStatsCollectorsFactory.java
@@ -127,9 +127,10 @@ public class StormNimbusStatsCollectorsFactory extends StatsCollectorsFactory<St
       throws StatsCollectorBadConfigurationException {
     Integer nimbusPort = null;
     String nimbusHost = null;
-    String nimbusHostParam = MonitorUtil.stripQuotes(monitorProperties.getProperty("NIMBUS_HOST", "localhost").trim())
-        .trim();
-    String portParam = MonitorUtil.stripQuotes(monitorProperties.getProperty("NIMBUS_PORT", "localhost").trim()).trim();
+    String nimbusHostParam = MonitorUtil.stripQuotes(MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties,
+        "NIMBUS_HOST", "localhost").trim()).trim();
+    String portParam = MonitorUtil.stripQuotes(MonitorUtil.getPropertyFromAnyNameVariant(monitorProperties,
+        "NIMBUS_PORT", "localhost").trim()).trim();
     if (nimbusHostParam != null && !nimbusHostParam.isEmpty()) {
       nimbusHost = nimbusHostParam;
     }

--- a/spm-monitor-utils/src/test/java/com/sematext/spm/client/MonitorUtilTest.java
+++ b/spm-monitor-utils/src/test/java/com/sematext/spm/client/MonitorUtilTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Sematext Group, Inc
+ *
+ * See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Sematext Group, Inc licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sematext.spm.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Properties;
+
+public class MonitorUtilTest {
+  @Test
+  public void testGetPropertyVariants() {
+    List<String> variants = MonitorUtil.getPropertyVariants("SPM_SOME_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
+    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
+    Assert.assertEquals("SOME_PROP", variants.get(2));
+
+    variants = MonitorUtil.getPropertyVariants("ST_SOME_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
+    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
+    Assert.assertEquals("SOME_PROP", variants.get(2));
+
+    variants = MonitorUtil.getPropertyVariants("SOME_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_SOME_PROP", variants.get(0));
+    Assert.assertEquals("SPM_SOME_PROP", variants.get(1));
+    Assert.assertEquals("SOME_PROP", variants.get(2));
+    
+    variants = MonitorUtil.getPropertyVariants("ST_TEST_PROP");
+    Assert.assertEquals(3, variants.size());
+    Assert.assertEquals("ST_TEST_PROP", variants.get(0));
+    Assert.assertEquals("SPM_TEST_PROP", variants.get(1));
+    Assert.assertEquals("TEST_PROP", variants.get(2));
+  }
+  
+  @Test
+  public void testGetPropertyFromAnyNameVariant() {
+    Properties props = new Properties();
+    props.put("PROP1", "prop1");
+    props.put("SPM_PROP2", "prop2");
+    props.put("ST_PROP3", "prop3");
+    
+    Assert.assertEquals("prop1", MonitorUtil.getPropertyFromAnyNameVariant(props, "PROP1", null));
+    Assert.assertEquals("prop1", MonitorUtil.getPropertyFromAnyNameVariant(props, "ST_PROP1", null));
+    Assert.assertEquals("prop1", MonitorUtil.getPropertyFromAnyNameVariant(props, "SPM_PROP1", null));
+    Assert.assertEquals(null, MonitorUtil.getPropertyFromAnyNameVariant(props, "PPPROP1", null));
+
+    Assert.assertEquals("prop2", MonitorUtil.getPropertyFromAnyNameVariant(props, "PROP2", null));
+    Assert.assertEquals("prop2", MonitorUtil.getPropertyFromAnyNameVariant(props, "ST_PROP2", null));
+    Assert.assertEquals("prop2", MonitorUtil.getPropertyFromAnyNameVariant(props, "SPM_PROP2", null));
+    Assert.assertEquals(null, MonitorUtil.getPropertyFromAnyNameVariant(props, "PPPROP2", null));
+
+    Assert.assertEquals("prop3", MonitorUtil.getPropertyFromAnyNameVariant(props, "PROP3", null));
+    Assert.assertEquals("prop3", MonitorUtil.getPropertyFromAnyNameVariant(props, "ST_PROP3", null));
+    Assert.assertEquals("prop3", MonitorUtil.getPropertyFromAnyNameVariant(props, "SPM_PROP3", null));
+    Assert.assertEquals(null, MonitorUtil.getPropertyFromAnyNameVariant(props, "PPPROP1", null));
+  }
+}


### PR DESCRIPTION
Add support for different attrib prefixes to Redis/HAProxy/Storm integrations

These 3 don't share common generic base and instead have their own collector factories. This meant they need to be individually adjusted for possibility of using different attribute prefixes.