### PR TITLE
Agent runtime status

### DIFF
--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/MonitorUtil.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/MonitorUtil.java
@@ -61,6 +61,7 @@ public final class MonitorUtil {
           System.getProperty("spm.home") : createPathString("opt", "spm");
 
   public static final String MONITOR_LOCK_FILE_DIR = FileUtil.path(SPM_HOME, "spm-monitor", "run");
+  public static final String MONITOR_STATUS_FILE_DIR = FileUtil.path(SPM_HOME, "spm-monitor", "run");
   public static final String MONITOR_APPLICATIONS_LOGS_BASE = createPathString(SPM_HOME, "spm-monitor", "logs", "applications");
 
   public static Integer MONITOR_PROCESS_ORDINAL = null;

--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
@@ -19,8 +19,6 @@
  */
 package com.sematext.spm.client.status;
 
-import com.amazonaws.services.ec2.model.Status;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;

--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
@@ -122,11 +122,13 @@ public class AgentStatusRecorder {
   public void updateMetricsCollected(boolean metricsCollected) {
     statusValues.put(METRICS_COLLECTED, metricsCollected);
     statusValues.put(LAST_UPDATE, new Date());
+    record();
   }
 
-  public void updateMetricsSent(boolean metricSent) {
-    statusValues.put(METRICS_SENT, metricSent);
+  public void updateMetricsSent(boolean metricsSent) {
+    statusValues.put(METRICS_SENT, metricsSent);
     statusValues.put(LAST_UPDATE, new Date());
+    record();
   }
 
   public void addConnectionError(String errorMessage) {

--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
@@ -22,7 +22,6 @@ package com.sematext.spm.client.status;
 import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -96,12 +95,12 @@ public class AgentStatusRecorder {
     
     this.statusFile = getStatusFile();
     
-    statusValues.put(StatusField.STARTED_AT, new Date());
-    statusValues.put(StatusField.LAST_UPDATE, new Date());
+    statusValues.put(StatusField.STARTED_AT, System.currentTimeMillis());
+    statusValues.put(StatusField.LAST_UPDATE, System.currentTimeMillis());
     statusValues.put(StatusField.METRICS_COLLECTED, false);
     statusValues.put(StatusField.METRICS_SENT, false);
     statusValues.put(StatusField.CONNECTION_STATUS, ConnectionStatus.CONNECTING);
-    statusValues.put(StatusField.CONNECTION_ERRORS, new HashMap<String, Date>());
+    statusValues.put(StatusField.CONNECTION_ERRORS, new HashMap<String, Long>());
 
     GLOBAL_INSTANCE = this;
     
@@ -110,7 +109,7 @@ public class AgentStatusRecorder {
   
   public void updateConnectionStatus(ConnectionStatus newStatus) {
     ConnectionStatus previousStatus = (ConnectionStatus) statusValues.get(StatusField.CONNECTION_STATUS);
-    Date now = new Date();
+    long now = System.currentTimeMillis();
     
     if (previousStatus == ConnectionStatus.CONNECTING || previousStatus == ConnectionStatus.FAILED) {
       // we can update in any case
@@ -120,7 +119,7 @@ public class AgentStatusRecorder {
       // setting to failed (e.g. in case of json some URLs may be ok, some not because of new version of monitored
       // service)
       if (newStatus == ConnectionStatus.FAILED) {
-        if ((now.getTime() - CONNECTION_OK_EXPIRY_TIME_MS) > lastConnectionOkStatusTime) {
+        if ((now - CONNECTION_OK_EXPIRY_TIME_MS) > lastConnectionOkStatusTime) {
           statusValues.put(StatusField.CONNECTION_STATUS, newStatus);  
         }
       } else {
@@ -138,28 +137,28 @@ public class AgentStatusRecorder {
   }
 
   public void updateConnectionStatus(ConnectionStatus newStatus, String newError) {
-    Map<String, Date> connErrors = (Map<String, Date>) statusValues.get(StatusField.CONNECTION_ERRORS);
-    connErrors.put(newError, new Date());
+    Map<String, Long> connErrors = (Map<String, Long>) statusValues.get(StatusField.CONNECTION_ERRORS);
+    connErrors.put(newError, System.currentTimeMillis());
     updateConnectionStatus(newStatus);
   }
 
   public void updateMetricsCollected(boolean metricsCollected) {
     statusValues.put(StatusField.METRICS_COLLECTED, metricsCollected);
-    statusValues.put(StatusField.LAST_UPDATE, new Date());
+    statusValues.put(StatusField.LAST_UPDATE, System.currentTimeMillis());
     record();
   }
 
   public void updateMetricsSent(boolean metricsSent) {
     statusValues.put(StatusField.METRICS_SENT, metricsSent);
-    statusValues.put(StatusField.LAST_UPDATE, new Date());
+    statusValues.put(StatusField.LAST_UPDATE, System.currentTimeMillis());
     record();
   }
 
   public void addConnectionError(String errorMessage) {
-    Map<String, Date> connErrors = (Map<String, Date>) statusValues.get(StatusField.CONNECTION_ERRORS);
-    connErrors.put(errorMessage, new Date());
+    Map<String, Long> connErrors = (Map<String, Long>) statusValues.get(StatusField.CONNECTION_ERRORS);
+    connErrors.put(errorMessage, System.currentTimeMillis());
 
-    statusValues.put(StatusField.LAST_UPDATE, new Date());
+    statusValues.put(StatusField.LAST_UPDATE, System.currentTimeMillis());
     
     record();
   }

--- a/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
+++ b/spm-monitor-utils/src/main/java/com/sematext/spm/client/status/AgentStatusRecorder.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Sematext Group, Inc
+ *
+ * See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Sematext Group, Inc licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sematext.spm.client.status;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.sematext.spm.client.Log;
+import com.sematext.spm.client.LogFactory;
+import com.sematext.spm.client.MonitorUtil;
+import com.sematext.spm.client.util.FileUtil;
+
+public class AgentStatusRecorder {
+  private static final Log LOG = LogFactory.getLog(AgentStatusRecorder.class);
+
+  public enum ConnectionStatus {
+    OK,
+    CONNECTING,
+    FAILED
+  }
+  
+  public static final String LAST_UPDATE = "lastUpdate";
+  public static final String STARTED_AT = "startedAt";
+  public static final String CONNECTION_ERRORS = "connectionErrors";
+  public static final String METRICS_COLLECTED = "metricsCollected";
+  public static final String METRICS_SENT = "metricsSent";
+
+  public static final String CONNECTION_STATUS = "connectionStatus";
+
+  private String appToken;
+  private String jvmName;
+  private String subType;
+  private Integer processOrdinal;
+  private Map<String, Object> statusValues = new TreeMap<String, Object>();
+  
+  private File statusFile;
+  
+
+  public AgentStatusRecorder(String appToken, File monitorPropertiesFile, Integer processOrdinal) {
+    this.appToken = appToken;
+    this.jvmName = MonitorUtil.extractJvmName(monitorPropertiesFile.getAbsolutePath(), appToken);
+    this.subType = MonitorUtil.extractConfSubtype(monitorPropertiesFile.getAbsolutePath());
+    this.processOrdinal = processOrdinal;
+    
+    this.statusFile = getStatusFile();
+    
+    statusValues.put(STARTED_AT, new Date());
+    statusValues.put(LAST_UPDATE, new Date());
+    statusValues.put(METRICS_COLLECTED, false);
+    statusValues.put(METRICS_SENT, false);
+    statusValues.put(CONNECTION_STATUS, ConnectionStatus.CONNECTING);
+    statusValues.put(CONNECTION_ERRORS, new HashMap<String, Date>());
+    
+    record();
+  }
+  
+  public void updateConnectionStatus(ConnectionStatus newStatus) {
+    statusValues.put(CONNECTION_STATUS, newStatus);
+    statusValues.put(LAST_UPDATE, new Date());
+
+    record();
+  }
+  
+  public void updateMetricsCollectedSent(boolean metricsCollected, boolean metricSent) {
+    statusValues.put(METRICS_COLLECTED, metricsCollected);
+    statusValues.put(METRICS_SENT, metricSent);
+    statusValues.put(LAST_UPDATE, new Date());
+  }
+  
+  public void addConnectionError(String errorMessage) {
+    Map<String, Date> connErrors = (Map<String, Date>) statusValues.get(CONNECTION_ERRORS);
+    connErrors.put(errorMessage, new Date());
+
+    statusValues.put(LAST_UPDATE, new Date());
+    
+    record();
+  }
+  
+  private void record() {
+    StringBuffer content = new StringBuffer(100);
+    for (String key : statusValues.keySet()) {
+      content.append(key);
+      content.append("=");
+      // raw serialization for now, but consider serializing e.g. errors differently
+      content.append(statusValues.get(key));
+      content.append(MonitorUtil.LINE_SEPARATOR);
+    }
+    
+    try {
+      FileUtil.write(content.toString(), statusFile);
+    } catch (IOException e) {
+      LOG.error("Can't write to status file", e);
+    }
+  }
+
+  private File getStatusFile() {
+    return new File(MonitorUtil.MONITOR_STATUS_FILE_DIR, getStatusFileName());
+  }
+
+  private String getStatusFileName() {
+    return appToken + "-" + subType + "-" + jvmName + "-monitor-" + processOrdinal + ".status";
+  }
+}

--- a/spm-monitor/src/main/java/com/sematext/spm/client/HeartbeatStatsCollector.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/HeartbeatStatsCollector.java
@@ -22,7 +22,6 @@ package com.sematext.spm.client;
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -90,11 +89,7 @@ public class HeartbeatStatsCollector extends MultipleStatsCollector<Integer> {
 
   @Override
   protected Collection<Integer> getSlice(Map<String, Object> outerMetrics) throws StatsCollectionFailedException {
-    if (CollectionStats.CURRENT_RUN_GATHERED_LINES.get() > 0) {
-      return HEARTBEAT;
-    } else {
-      return NO_HEARTBEAT;
-    }
+    return CollectionStats.CURRENT_RUN_GATHERED_LINES.get() > 0 ? HEARTBEAT : NO_HEARTBEAT;
   }
 
   @Override

--- a/spm-monitor/src/main/java/com/sematext/spm/client/db/DbConnectionManager.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/db/DbConnectionManager.java
@@ -26,6 +26,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.sematext.spm.client.Log;
 import com.sematext.spm.client.LogFactory;
+import com.sematext.spm.client.status.AgentStatusRecorder;
+import com.sematext.spm.client.status.AgentStatusRecorder.ConnectionStatus;
 
 /**
  * Handles creation of single connection to some DB, knows how to reconnect in case of problems, takes care of
@@ -158,7 +160,10 @@ public class DbConnectionManager {
         throw new IllegalStateException("DriverManager.getConnection didn't produce connection or error for " +
                                             "url: " + dbUrl + ", user: " + user);
       }
+      
+      AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.OK);
     } catch (Throwable thr) {
+      AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.FAILED, thr.getMessage());
       if (consecutiveConnErrors == 0) {
         // print stacktrace only for first error, no need to fill logs with pile of exactly the same exception traces
         LOG.error("Error while creating DB connection to url:" + dbUrl + ", user: " + user +

--- a/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractorConfig.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/db/DbStatsExtractorConfig.java
@@ -29,6 +29,8 @@ import com.sematext.spm.client.config.CollectorFileConfig;
 import com.sematext.spm.client.config.DataConfig;
 import com.sematext.spm.client.config.DbDriverConfig;
 import com.sematext.spm.client.config.ObservationDefinitionConfig;
+import com.sematext.spm.client.status.AgentStatusRecorder;
+import com.sematext.spm.client.status.AgentStatusRecorder.ConnectionStatus;
 
 public class DbStatsExtractorConfig extends StatsExtractorConfig<DbObservation> {
   private String dataRequestQuery;
@@ -76,7 +78,11 @@ public class DbStatsExtractorConfig extends StatsExtractorConfig<DbObservation> 
         }
 
         if (dbDriverClass == null) {
-          throw new ConfigurationFailedException("Cannot load db driver class. Please check if the JDBC driver is in classpath");
+          String msg = "Cannot load db driver class. Please check if the JDBC driver is in classpath";
+          if (AgentStatusRecorder.GLOBAL_INSTANCE != null) {
+            AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.FAILED, msg);
+          }
+          throw new ConfigurationFailedException(msg);
         }
 
       } else {

--- a/spm-monitor/src/main/java/com/sematext/spm/client/http/CachableReliableDataSourceBase.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/http/CachableReliableDataSourceBase.java
@@ -19,12 +19,15 @@
  */
 package com.sematext.spm.client.http;
 
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.sematext.spm.client.Log;
 import com.sematext.spm.client.LogFactory;
 import com.sematext.spm.client.MonitorConfig;
 import com.sematext.spm.client.json.JsonDataSourceCachedFactory;
+import com.sematext.spm.client.status.AgentStatusRecorder;
+import com.sematext.spm.client.status.AgentStatusRecorder.ConnectionStatus;
 
 public class CachableReliableDataSourceBase<T, D extends DataProvider<T>> {
   private static final Log LOG = LogFactory.getLog(CachableReliableDataSourceBase.class);
@@ -124,6 +127,8 @@ public class CachableReliableDataSourceBase<T, D extends DataProvider<T>> {
       T newData = dataProvider.getData();
 
       if (newData == null) {
+        AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.FAILED, "no data in response");
+        
         LOG.error("Error while fetching data with " + this.getClass().getCanonicalName() +
                       " for " + dataProvider + " - no String with response data could be created.");
 
@@ -138,8 +143,12 @@ public class CachableReliableDataSourceBase<T, D extends DataProvider<T>> {
 
       data.setData(newData);
 
+      AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.OK);
+
       return;
     } catch (Throwable thr) {
+      AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.FAILED, thr.getMessage());
+      
       LOG.error("Error while fetching data with " + this.getClass().getCanonicalName() +
                     " for " + dataProvider + ". Message: " + thr.getMessage());
 

--- a/spm-monitor/src/main/java/com/sematext/spm/client/jmx/JmxMBeanServerConnectionWrapper.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/jmx/JmxMBeanServerConnectionWrapper.java
@@ -31,6 +31,9 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import com.sematext.spm.client.Log;
 import com.sematext.spm.client.LogFactory;
+import com.sematext.spm.client.status.AgentStatusRecorder;
+import com.sematext.spm.client.status.AgentStatusRecorder.ConnectionStatus;
+
 import java.rmi.server.RMISocketFactory;
 
 /**
@@ -133,7 +136,9 @@ public final class JmxMBeanServerConnectionWrapper {
       lastSuccessTime = System.currentTimeMillis();
       lastFailedTime = 0L;
       consecutiveConnErrors = 0;
+      AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.OK);
     } catch (Throwable thr) {
+      AgentStatusRecorder.GLOBAL_INSTANCE.updateConnectionStatus(ConnectionStatus.FAILED, thr.getMessage());
       if (consecutiveConnErrors == 0) {
         // print stacktrace only for first error, no need to fill logs with pile of exactly the same exception traces
         LOG.error("Can't connect to JMX server " + ctx.getUrl() + " with user " + ctx.getUsername(), thr);

--- a/spm-sender/src/main/java/com/sematext/spm/client/MonitorConfig.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/MonitorConfig.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import com.sematext.spm.client.status.AgentStatusRecorder;
+import com.sematext.spm.client.status.AgentStatusRecorder.ConnectionStatus;
 import com.sematext.spm.client.util.StringUtils;
 
 /**
@@ -75,6 +77,8 @@ public class MonitorConfig extends InMemoryConfig {
   private String metricCollectorsConfigValue;
 
   private TagAliasSender tagAliasSender;
+  
+  private AgentStatusRecorder statusRecorder;
 
   public MonitorConfig(String appToken, File monitorPropertiesFile, DataFormat format, Integer processOrdinal)
       throws ConfigurationFailedException {
@@ -86,6 +90,7 @@ public class MonitorConfig extends InMemoryConfig {
     this.monitorPropertiesFile = monitorPropertiesFile;
     this.processOrdinal = processOrdinal;
     this.format = format;
+    this.statusRecorder = new AgentStatusRecorder(appToken, monitorPropertiesFile, processOrdinal);
     loadConfig();
   }
 
@@ -379,5 +384,9 @@ public class MonitorConfig extends InMemoryConfig {
 
   public String getSubType() {
     return subType;
+  }
+
+  public AgentStatusRecorder getStatusRecorder() {
+    return statusRecorder;
   }
 }

--- a/spm-sender/src/main/java/com/sematext/spm/client/StatsMetricsLogLineSender.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/StatsMetricsLogLineSender.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.sematext.spm.client.Sender.SenderType;
+import com.sematext.spm.client.status.AgentStatusRecorder;
 
 public class StatsMetricsLogLineSender implements StatsLogLineBuilder<String, StatsCollector<String>> {
   private static final Log LOG = LogFactory.getLog(StatsMetricsLogLineSender.class);
@@ -95,6 +96,12 @@ public class StatsMetricsLogLineSender implements StatsLogLineBuilder<String, St
         // in this case we will stop further writing to the channel
         LOG.error("Failed to add stats line to flume channel, skipping writing of remaining lines", ce);
         break;
+      }
+    }
+    
+    if (CollectionStats.CURRENT_RUN_GATHERED_LINES.get() > 0) {
+      if (AgentStatusRecorder.GLOBAL_INSTANCE != null) {
+        AgentStatusRecorder.GLOBAL_INSTANCE.updateMetricsCollected(true);
       }
     }
 

--- a/spm-sender/src/main/java/com/sematext/spm/client/sender/flume/influx/HttpInfluxClient.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/sender/flume/influx/HttpInfluxClient.java
@@ -47,6 +47,8 @@ import com.sematext.spm.client.Log;
 import com.sematext.spm.client.LogFactory;
 import com.sematext.spm.client.sender.flume.SinkConstants;
 import com.sematext.spm.client.sender.flume.es.ProxyContext;
+import com.sematext.spm.client.status.AgentStatusRecorder;
+import com.sematext.spm.client.status.AgentStatusRecorder.ConnectionStatus;
 
 public class HttpInfluxClient extends InfluxClient {
   private static final Log logger = LogFactory.getLog(HttpInfluxClient.class);
@@ -207,6 +209,10 @@ public class HttpInfluxClient extends InfluxClient {
           // throw (which causes retry) only if it was not a case of bad request (which would fail again)
           throw new EventDeliveryException(msg);
         }
+      }
+      
+      if (AgentStatusRecorder.GLOBAL_INSTANCE != null) {
+        AgentStatusRecorder.GLOBAL_INSTANCE.updateMetricsSent(true);
       }
 
       logger.info("Batch of size " + entity.length() + " chars successfully sent");

--- a/spm-sender/src/main/java/com/sematext/spm/client/sender/flume/influx/InfluxSink.java
+++ b/spm-sender/src/main/java/com/sematext/spm/client/sender/flume/influx/InfluxSink.java
@@ -38,6 +38,7 @@ import com.sematext.spm.client.LogFactory;
 import com.sematext.spm.client.sender.flume.SinkConstants;
 import com.sematext.spm.client.sender.flume.es.ProxyContext;
 import com.sematext.spm.client.sender.util.DynamicUrlParamSink;
+import com.sematext.spm.client.status.AgentStatusRecorder;
 
 /*CHECKSTYLE:OFF*/
 public class InfluxSink extends AbstractSink implements DynamicUrlParamSink {
@@ -133,6 +134,10 @@ public class InfluxSink extends AbstractSink implements DynamicUrlParamSink {
       sinkCounter.addToEventDrainSuccessCount(count);
       counterGroup.incrementAndGet("transaction.success");
     } catch (Throwable ex) {
+      if (AgentStatusRecorder.GLOBAL_INSTANCE != null) {
+        AgentStatusRecorder.GLOBAL_INSTANCE.updateMetricsSent(false);
+      }
+
       lastDataSendingTime = System.currentTimeMillis();
       try {
         txn.rollback();


### PR DESCRIPTION
Start writing agent status info into file

The file is located in `/opt/spm/spm-monitor/run`, it is named like `/opt/spm/spm-monitor/run/53fcaf0a-de07-4b46-bacc-0f60f6bcbf33--default-monitor-0.status` (same format as `.lock` files, but with different extension). Few examples of content:

```
startedAt=1595431789086
lastUpdate=1595432809975
metricsCollected=true
metricsSent=true
connectionStatus=OK
connectionErrors={}
```

```
startedAt=1595431789086
lastUpdate=1595432809975
metricsCollected=false
metricsSent=false
connectionStatus=FAILED
connectionErrors={Cannot load db driver class. Please check if the JDBC driver is in classpath=1595432214479}
```

I am not entirely happy with the implementation - AgentStatusRecorder instance being static and sprinkling N places in code with logic that calls different AgentStatusRecorder methods. Ideally this would be done in transparent and generic way, but making it right would require huge refactoring, so decided against it.