### PR TITLE
Support json tags extraction

### DIFF
--- a/spm-monitor-generic/src/main/java/com/sematext/spm/client/functions/json/ConcatCollection.java
+++ b/spm-monitor-generic/src/main/java/com/sematext/spm/client/functions/json/ConcatCollection.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Sematext Group, Inc
+ *
+ * See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Sematext Group, Inc licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sematext.spm.client.functions.json;
+
+import com.sematext.spm.client.JsonFunction;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * For Collection type of objects, concatenates all values into a single string with comma as a separator.
+ * Otherwise returns null.
+ */
+public class ConcatCollection implements JsonFunction {
+    @Override
+    public String toString(Object object) {
+      if (object != null) {
+        if (object instanceof Collection) {
+          Collection col = (Collection) object;
+
+          if (col.size() > 0) {
+            Iterator iter = col.iterator();
+            StringBuilder sb = new StringBuilder();
+
+            while (iter.hasNext()) {
+              if (sb.length() > 0) {
+                 sb.append(",");
+              }
+              sb.append(iter.next());
+            }
+
+          return sb.toString();
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/spm-monitor/src/main/java/com/sematext/spm/client/JsonFunction.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/JsonFunction.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Sematext Group, Inc
+ *
+ * See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Sematext Group, Inc licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sematext.spm.client;
+
+/**
+ * Interface for functions that convert various kinds of Objects found in JSON responses into a single String value.
+ */
+public interface JsonFunction {
+  String toString(Object object);
+}

--- a/spm-monitor/src/main/java/com/sematext/spm/client/JsonFunctionFactory.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/JsonFunctionFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Sematext Group, Inc
+ *
+ * See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Sematext Group, Inc licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sematext.spm.client;
+
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+
+import java.util.Map;
+
+public final class JsonFunctionFactory {
+  private static Map<String, JsonFunction> JSON_FUNCTIONS_MAP = new UnifiedMap<String, JsonFunction>();
+
+  private JsonFunctionFactory() {}
+
+  public static JsonFunction getFunction(String name) {
+    if (!JSON_FUNCTIONS_MAP.containsKey(name)) {
+      try {
+        String className = name;
+
+        // if the classname does not contain a package, prepend the default package
+        if (!className.contains(".")) {
+          className = "com.sematext.spm.client.functions.json." + className;
+        }
+
+        Class<?> c = Class.forName(className);
+        JsonFunction function = (JsonFunction) c.newInstance();
+        JSON_FUNCTIONS_MAP.put(name, function);
+      } catch (Throwable thr) {
+        JSON_FUNCTIONS_MAP.put(name, null);
+        throw new UnsupportedOperationException(String.format("Unknown function %s", name));
+      }
+    }
+
+    return JSON_FUNCTIONS_MAP.get(name);
+  }
+}

--- a/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonPathExpressionParser.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonPathExpressionParser.java
@@ -62,19 +62,7 @@ public final class JsonPathExpressionParser {
   }
 
   public static boolean isFunction(String node) {
-    // no support for functions with args for now
-    String funcTrimmed = node.replaceAll(" ", "");
-    if (funcTrimmed.endsWith("()")) {
-      return true;
-    }
-
-    // also check if there is a Java class that is implemented as a function
-    try {
-      JsonFunction func = JsonFunctionFactory.getFunction(funcTrimmed);
-      return func != null;
-    } catch (UnsupportedOperationException e) {
-      return false;
-    }
+    return node.replaceAll(" ", "").endsWith("()");
   }
 
   public static boolean isPlaceholder(String value) {

--- a/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonPathExpressionParser.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonPathExpressionParser.java
@@ -21,6 +21,8 @@ package com.sematext.spm.client.json;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.sematext.spm.client.JsonFunction;
+import com.sematext.spm.client.JsonFunctionFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +63,18 @@ public final class JsonPathExpressionParser {
 
   public static boolean isFunction(String node) {
     // no support for functions with args for now
-    return node.replaceAll(" ", "").endsWith("()");
+    String funcTrimmed = node.replaceAll(" ", "");
+    if (funcTrimmed.endsWith("()")) {
+      return true;
+    }
+
+    // also check if there is a Java class that is implemented as a function
+    try {
+      JsonFunction func = JsonFunctionFactory.getFunction(funcTrimmed);
+      return func != null;
+    } catch (UnsupportedOperationException e) {
+      return false;
+    }
   }
 
   public static boolean isPlaceholder(String value) {

--- a/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonUtilFunctionEvaluator.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/json/JsonUtilFunctionEvaluator.java
@@ -19,6 +19,9 @@
  */
 package com.sematext.spm.client.json;
 
+import com.sematext.spm.client.JsonFunction;
+import com.sematext.spm.client.JsonFunctionFactory;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -56,7 +59,13 @@ public final class JsonUtilFunctionEvaluator {
     } else if ("avg".equals(function)) {
       result = summarizeElements(node, elementCollection) / elementCollection.size();
     } else {
-      throw new UnsupportedOperationException(String.format("Unknown function %s", node));
+      // check if there is a function class, run it if there is
+      JsonFunction calcFunction = JsonFunctionFactory.getFunction(function);
+      if (function != null) {
+        return calcFunction.toString(elementCollection);
+      } else {
+        throw new UnsupportedOperationException(String.format("Unknown function %s", node));
+      }
     }
     return result;
   }

--- a/spm-monitor/src/main/java/com/sematext/spm/client/observation/JsonExpressionReturnValue.java
+++ b/spm-monitor/src/main/java/com/sematext/spm/client/observation/JsonExpressionReturnValue.java
@@ -161,7 +161,6 @@ class FunctionReturnValue extends ReturnValue {
   private ReturnValue nestedReturnValue;
   
   public static boolean applies(String expression) {
-    // just substring supported for now
     return expression != null && (isSubstring(expression) || isCast(expression) ||
         JsonPathExpressionParser.isFunction(expression));
   }


### PR DESCRIPTION
Added support to extract tag value from lists/maps found in json structure. To achieve that, I added a way to create a Java class that contains the logic used to produce a single-string value as a result. In this case we have to concatenate N values found in `roles` list, but in the future this functionality can be used for many other use-cases.