### PR TITLE
SC-13234 Avoid NullPointerException when java-agent is not able to read the config file

### DIFF
--- a/spm-monitor-starter/src/main/java/com/sematext/spm/client/MonitorAgentBootstrapThread.java
+++ b/spm-monitor-starter/src/main/java/com/sematext/spm/client/MonitorAgentBootstrapThread.java
@@ -114,8 +114,8 @@ public class MonitorAgentBootstrapThread extends Thread {
       System.out.println("Monitor config file is : " + monitorConfigFile);
       Properties monitorProps = MonitorUtil.loadMonitorProperties(monitorConfigFile);
 
-      if(monitorProps == null) {
-        System.out.println("Unable to open monitor config file.");
+      if(monitorProps == null){
+        System.out.println("Unable to open monitor config file: " + monitorConfigFile);
         return;
       }
 

--- a/spm-monitor-starter/src/main/java/com/sematext/spm/client/MonitorAgentBootstrapThread.java
+++ b/spm-monitor-starter/src/main/java/com/sematext/spm/client/MonitorAgentBootstrapThread.java
@@ -113,6 +113,12 @@ public class MonitorAgentBootstrapThread extends Thread {
 
       System.out.println("Monitor config file is : " + monitorConfigFile);
       Properties monitorProps = MonitorUtil.loadMonitorProperties(monitorConfigFile);
+
+      if(monitorProps == null) {
+        System.out.println("Unable to open monitor config file.");
+        return;
+      }
+
       String collectors = MonitorUtil.stripQuotes(monitorProps.getProperty("SPM_MONITOR_COLLECTORS").trim()).trim();
       for (String collector : collectors.split(",")) {
         collector = collector.trim();


### PR DESCRIPTION
Added a null check to see if config file can be opened.