### PR TITLE
Bump hsqldb from 2.3.2 to 2.7.1 in /spm-tracing-agent

### DIFF
--- a/spm-tracing-agent/pom.xml
+++ b/spm-tracing-agent/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.2</version>
+      <version>2.7.1</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
#135  hsqldb from 2.3.2 to 2.7.1.

---
updated-dependencies:
- dependency-name: org.hsqldb:hsqldb dependency-type: direct:development ...

Signed-off-by: dependabot[bot] <support@github.com>