### PR TITLE
[SC-23347] fix(redis): remove duplicate redis prefix from memory metrics

### DIFF
--- a/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisStatsCollector.java
+++ b/spm-monitor-redis/src/main/java/com/sematext/spm/client/redis/RedisStatsCollector.java
@@ -90,8 +90,8 @@ public class RedisStatsCollector extends SingleStatsCollector {
 
     statValues.setMetrics(new UnifiedMap<String, Object>());
     statValues.getMetrics().put("memory.used", extractors.get(0).extract(info));
-    statValues.getMetrics().put("redis.memory.used.max", extractors.get(1).extract(info));
-    statValues.getMetrics().put("redis.memory.used.rss", extractors.get(2).extract(info));
+    statValues.getMetrics().put("memory.used.max", extractors.get(1).extract(info));
+    statValues.getMetrics().put("memory.used.rss", extractors.get(2).extract(info));
     statValues.getMetrics().put("clients.connected", extractors.get(3).extract(info));
     statValues.getMetrics().put("replication.slaves.connected", extractors.get(4).extract(info));
     statValues.getMetrics().put("replication.master.last.io.seconds.ago", extractors.get(5).extract(info));


### PR DESCRIPTION
Remove redis. prefix from memory.used.max and memory.used.rss field names. The LineProtocolParser already prepends the measurement name (redis.) to all fields, causing double-prefixed metric names (redis.redis.memory.used.max)
<img width="369" height="242" alt="Screenshot 2025-12-03 at 13 15 32" src="https://github.com/user-attachments/assets/cc02852d-db63-4c2b-a8de-eda9c921234c" />

